### PR TITLE
Restore hash updates

### DIFF
--- a/.github/update_nightly.js
+++ b/.github/update_nightly.js
@@ -1,6 +1,6 @@
 const fs = require("fs").promises;
 const crypto = require("crypto");
-const https = require("https");
+const { https } = require('follow-redirects');
 
 async function main({github, core}) {
     const [owner, repo] = ["crystal-lang", "crystal"];

--- a/.github/workflows/update.yml
+++ b/.github/workflows/update.yml
@@ -11,6 +11,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version: 16
+      - run: npm install follow-redirects
       - uses: actions/github-script@v5
         with:
           script: |

--- a/bucket/crystal.json
+++ b/bucket/crystal.json
@@ -10,13 +10,13 @@
         "https://nightly.link/crystal-lang/crystal/actions/artifacts/120537469.zip",
         "https://raw.githubusercontent.com/neatorobito/scoop-crystal/3d681f1e4cbcf2bac91dc385b1a82034d14ee177/scripts/crystal.ps1"
     ],
+    "hash": [
+        "",
+        "06E4EF2B7196080887A4FEE4B235CC1C3F5B7F8D55A8A67509CD26BDAD53F968"
+    ],
     "depends": [
         "vswhere",
         "git"
-    ],
-    "extract_to": [
-        "",
-        ""
     ],
     "env_add_path": ".",
     "bin": [

--- a/bucket/crystal.json
+++ b/bucket/crystal.json
@@ -1,17 +1,17 @@
 {
-    "version": "1.2.2.7",
-    "description": "Crystal programming language preview @ baf5c3b30",
+    "version": "1.2.2.8",
+    "description": "Crystal programming language preview @ 1e73e9cef",
     "homepage": "https://crystal-lang.org/",
     "license": {
         "identifier": "Freeware",
         "url": "https://github.com/crystal-lang/crystal/blob/master/LICENSE"
     },
     "url": [
-        "https://nightly.link/crystal-lang/crystal/actions/artifacts/120537469.zip",
+        "https://nightly.link/crystal-lang/crystal/actions/artifacts/120863414.zip",
         "https://raw.githubusercontent.com/neatorobito/scoop-crystal/3d681f1e4cbcf2bac91dc385b1a82034d14ee177/scripts/crystal.ps1"
     ],
     "hash": [
-        "",
+        "0262D79F934C4ADB0C1C6084FAE44B52B44EF6A0A1A9331617361B781ADAE3E1",
         "06E4EF2B7196080887A4FEE4B235CC1C3F5B7F8D55A8A67509CD26BDAD53F968"
     ],
     "depends": [


### PR DESCRIPTION
Update nightly wasn't calculating the correct hash for the file because the baked in node https module doesn't follow redirects. It was returning the hash for some HTML resource. It's a bit heavy, but I just added a drop in replacement for the node https module that follows redirects.

I ran the workflow manually and it calculated the correct hash and scoop was happy. Compilation still works as well ofc.

![image](https://user-images.githubusercontent.com/3013405/144313791-c098910d-c4b4-4a0a-a04c-f689bbc94010.png)
