### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@ This repo provides a way to try the Crystal programming language on Windows.
 ## Getting started
 
 ### Requirements
-1. [Scoop package manager](https://scoop.sh/)
-2. Visual Studio or Visual Studio Build Tools with `Microsoft.VisualStudio.Workload.VCTools` and `Microsoft.VisualStudio.Component.VC.ATL` components. 
+1. Enable developer mode in Settings.
+2. [Scoop package manager](https://scoop.sh/)
+3. Visual Studio or Visual Studio Build Tools with `Microsoft.VisualStudio.Workload.VCTools` and `Microsoft.VisualStudio.Component.VC.ATL` components. 
      * If you already have an existing Visual Studio installation (2017 or later), open the installer and simply select these components under Desktop Development. 
      * Otherwise you can install a smaller subset of Visual Studio with only the tools you need from this bucket, see below.
 


### PR DESCRIPTION
File.symlink on Windows creates a symbolic link rather than a junction (reparse point). Typically you would need administrator privileges to create a symbolic link, but with the addition and correct usage of SYMBOLIC_LINK_FLAG_ALLOW_UNPRIVILEGED_CREATE [in the crystal standard library](https://github.com/crystal-lang/crystal/blob/3ff400035ec505e6c368dbafbd2dc14124fd95eb/src/crystal/system/win32/file.cr#L205), you can create symbolic links without those privileges as long as developer mode is enabled.

Biggest impact is for Shards, which creates symlinks at install time, so updating the README with these notes ensures a frictionless experience with the package manager.