### PR TITLE
Fix find `windows-msvc` artifact

### DIFF
--- a/.github/update_mainline.js
+++ b/.github/update_mainline.js
@@ -15,7 +15,7 @@ async function main({github, core}) {
     }
 
     const windowsRelease = assets.find(
-        platformRelease => (platformRelease.name.includes("windows") && platformRelease.name.includes(".zip"))
+        platformRelease => (platformRelease.name.includes("windows-x86_64-msvc") && platformRelease.name.includes(".zip"))
     );
 
     if(!windowsRelease) {


### PR DESCRIPTION
Narrows down the name of the release artifact to the toolchain (`msvc`) and also the architecture (`x86_64`). Since 1.15 we're releasing `gnu` builds for Windows as well. In the future there might be aarch64 builds.
It might also be an option to switch entirely to the gnu builds, but for now this is the easiest bug fix.

Resolves #37